### PR TITLE
Docs tweak: automodapi on modules

### DIFF
--- a/docs/tayph/index.rst
+++ b/docs/tayph/index.rst
@@ -7,4 +7,23 @@ This is the documentation for tayph.
 Reference/API
 =============
 
-.. automodapi:: tayph
+.. automodapi:: tayph.ccf
+
+.. automodapi:: tayph.functions
+
+.. automodapi:: tayph.models
+
+.. automodapi:: tayph.operations
+
+.. automodapi:: tayph.plotting
+
+.. automodapi:: tayph.run
+
+.. automodapi:: tayph.system_parameters
+
+.. automodapi:: tayph.tellurics
+
+.. automodapi:: tayph.util
+
+.. automodapi:: tayph.vartests
+


### PR DESCRIPTION
Hi @Hoeijmakers!

I'm silly. I forgot that I already knew how to make your API Index a bit more organized, and it's pretty simple. I remembered when I was making the docs for a package I'm working on, and I whipped up a solution for you. You just have to tell `automodapi` to document each of the modules, and you get docs that look like this:

<img width="1093" alt="Screen Shot 2020-08-23 at 08 27 43" src="https://user-images.githubusercontent.com/3497584/90972611-e4472680-e51a-11ea-9e33-4a9d7d209750.png">

Cheers to tayph! 🌈 