### PR TITLE
Updating drag_color.py script, to be compatable with updated versions of matplotlib

### DIFF
--- a/tayph/drag_colour.py
+++ b/tayph/drag_colour.py
@@ -206,13 +206,13 @@ class DraggableColorbar(object):
         self.cbar_name = cbar_name
     def connect(self):
         """connect to all the events we need"""
-        self.cidpress = self.cbar.patch.figure.canvas.mpl_connect(
+        self.cidpress = self.cbar.outline.figure.canvas.mpl_connect(
             'button_press_event', self.on_press)
-        self.cidrelease = self.cbar.patch.figure.canvas.mpl_connect(
+        self.cidrelease = self.cbar.outline.figure.canvas.mpl_connect(
             'button_release_event', self.on_release)
-        self.cidmotion = self.cbar.patch.figure.canvas.mpl_connect(
+        self.cidmotion = self.cbar.outline.figure.canvas.mpl_connect(
             'motion_notify_event', self.on_motion)
-        self.keypress = self.cbar.patch.figure.canvas.mpl_connect(
+        self.keypress = self.cbar.outline.figure.canvas.mpl_connect(
             'key_press_event', self.key_press)
 
     def on_press(self, event):
@@ -234,7 +234,7 @@ class DraggableColorbar(object):
         self.cbar.draw_all()
         self.mappable.set_cmap(cmap)
         self.mappable.get_axes().set_title(cmap)
-        self.cbar.patch.figure.canvas.draw()
+        self.cbar.outline.figure.canvas.draw()
 
     def on_motion(self, event):
         'on motion we will move the rect if the mouse is over us'
@@ -255,20 +255,20 @@ class DraggableColorbar(object):
             self.cbar.norm.vmax += (perc*scale)*np.sign(dy)
         self.cbar.draw_all()
         self.mappable.set_norm(self.cbar.norm)
-        self.cbar.patch.figure.canvas.draw()
+        self.cbar.outline.figure.canvas.draw()
 
 
     def on_release(self, event):
         """on release we reset the press data"""
         self.press = None
         self.mappable.set_norm(self.cbar.norm)
-        self.cbar.patch.figure.canvas.draw()
+        self.cbar.outline.figure.canvas.draw()
 
     def disconnect(self):
         """disconnect all the stored connection ids"""
-        self.cbar.patch.figure.canvas.mpl_disconnect(self.cidpress)
-        self.cbar.patch.figure.canvas.mpl_disconnect(self.cidrelease)
-        self.cbar.patch.figure.canvas.mpl_disconnect(self.cidmotion)
+        self.cbar.outline.figure.canvas.mpl_disconnect(self.cidpress)
+        self.cbar.outline.figure.canvas.mpl_disconnect(self.cidrelease)
+        self.cbar.outline.figure.canvas.mpl_disconnect(self.cidmotion)
 
 
 
@@ -288,13 +288,13 @@ class DraggableColorbar_fits(object):
 
     def connect(self):
         """connect to all the events we need"""
-        self.cidpress = self.cbar.patch.figure.canvas.mpl_connect(
+        self.cidpress = self.cbar.outline.figure.canvas.mpl_connect(
             'button_press_event', self.on_press)
-        self.cidrelease = self.cbar.patch.figure.canvas.mpl_connect(
+        self.cidrelease = self.cbar.outline.figure.canvas.mpl_connect(
             'button_release_event', self.on_release)
-        self.cidmotion = self.cbar.patch.figure.canvas.mpl_connect(
+        self.cidmotion = self.cbar.outline.figure.canvas.mpl_connect(
             'motion_notify_event', self.on_motion)
-        self.keypress = self.cbar.patch.figure.canvas.mpl_connect(
+        self.keypress = self.cbar.outline.figure.canvas.mpl_connect(
             'key_press_event', self.key_press)
 
     def on_press(self, event):
@@ -316,7 +316,7 @@ class DraggableColorbar_fits(object):
         self.cbar.draw_all()
         self.mappable.set_cmap(cmap)
         self.mappable.get_axes().set_title(cmap)
-        self.cbar.patch.figure.canvas.draw()
+        self.cbar.outline.figure.canvas.draw()
 
     def on_motion(self, event):
         'on motion we will move the rect if the mouse is over us'
@@ -345,7 +345,7 @@ class DraggableColorbar_fits(object):
                 subplot.set_norm(self.cbar.norm)
         else:
             self.mappable.set_norm(self.cbar.norm)
-        self.cbar.patch.figure.canvas.draw()
+        self.cbar.outline.figure.canvas.draw()
 
 
     def on_release(self, event):
@@ -356,10 +356,10 @@ class DraggableColorbar_fits(object):
                 subplot.set_norm(self.cbar.norm)
         else:
             self.mappable.set_norm(self.cbar.norm)
-        self.cbar.patch.figure.canvas.draw()
+        self.cbar.outline.figure.canvas.draw()
 
     def disconnect(self):
         """disconnect all the stored connection ids"""
-        self.cbar.patch.figure.canvas.mpl_disconnect(self.cidpress)
-        self.cbar.patch.figure.canvas.mpl_disconnect(self.cidrelease)
-        self.cbar.patch.figure.canvas.mpl_disconnect(self.cidmotion)
+        self.cbar.outline.figure.canvas.mpl_disconnect(self.cidpress)
+        self.cbar.outline.figure.canvas.mpl_disconnect(self.cidrelease)
+        self.cbar.outline.figure.canvas.mpl_disconnect(self.cidmotion)

--- a/tayph/read.py
+++ b/tayph/read.py
@@ -1009,7 +1009,7 @@ def read_hires_makee(inpath,filelist,construct_s1d=True,N_CCD=3):
     wave=[]
 
     catkeyword = 'OBSTYPE'
-    bervkeyword = 'HELIOVEL'
+    #bervkeyword = 'HELIOVEL'
     thfilekeyword = 'ARCSPFIL'
 
     # wavefile_used = []

--- a/tayph/system_parameters.py
+++ b/tayph/system_parameters.py
@@ -299,11 +299,15 @@ def calculateberv(date,earth_coordinates,ra,dec,mode=False):
         sc = SkyCoord(ra=ra * u.deg,
                       dec=dec * u.deg)
 
-    elif mode in ['UVES-red', 'UVES-blue',"FOCES"]:
+    elif mode in ['UVES-red', 'UVES-blue',"FOCES","HIRES-MAKEE"]:
         observatory = EarthLocation.from_geodetic(lat=earth_coordinates[0]*u.deg,
                                                   lon=earth_coordinates[1]*u.deg,
                                                   height=earth_coordinates[2]*u.m)
         sc = SkyCoord(f'{ra} {dec}', unit=(u.hourangle, u.deg))
+
+        if mode == "HIRES-MAKEE":
+            timeval = Time(date,format='isot', scale='utc')
+            date = timeval.mjd
 
     barycorr = sc.radial_velocity_correction(obstime=Time(date,format='mjd'), location=observatory).to(u.km/u.s)
     return(barycorr.value)


### PR DESCRIPTION
In the drag_color.py script, the patch attribute is called from Colorbar. However, in more recent versions of Matplotlib (starting from version 3.4.0), the Colorbar object no longer has a patch attribute. Instead, it uses the outline attribute to access the rectangular patch of the colorbar. Therefore, replacing all instances of patch with outline in the script should fix this issue.

This issue occurs because the Colorbar object was updated in recent versions of Matplotlib, and some of the attributes and methods have been changed or removed. As a result, code that was written for older versions of Matplotlib may not work correctly in newer versions.

To avoid this issue, it's a good idea to check the version of Matplotlib you're using and make sure that any code you're using is compatible with that version. If you're using an older version of Matplotlib, you may need to update your code to work with newer versions.