### PR TITLE
Fix x=0 case

### DIFF
--- a/tayph/util.py
+++ b/tayph/util.py
@@ -67,7 +67,7 @@ def statusbar(i,x):
         Either the total number of iterations (int/float) or
         the array through which is looped.
     """
-    if (type(x) == int or type(x) == float) and x > 1:
+    if (type(x) == int or type(x) == float):
         print('  '+f"{i/(float(x)-1)*100:.1f} %", end="\r")
     elif len(x)>1:
         print('  '+f"{i/(len(x)-1)*100:.1f} %", end="\r")#Statusbar.


### PR DESCRIPTION
For x=0, the statusbar crashes. So if you only have one order, it will not work.