### PR TITLE
Update pyproject.toml to no longer have requirement on cython

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,6 @@ requires = ["setuptools",
             "wheel",
             "extension-helpers",
             "oldest-supported-numpy",
-            "cython==0.29.14"]
+            "cython"]
 
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
cython version requirements no longer needed for any new to not-even-new python installations anymore